### PR TITLE
Web & API - ReplicaSet Support & Job Display Fix

### DIFF
--- a/api/auth/fakes/rbac.go
+++ b/api/auth/fakes/rbac.go
@@ -112,8 +112,16 @@ func (ra RoleAssignment) HasDaemonSetAccess(labels map[string]string) bool {
 	return true
 }
 
-// HasJobAccess returns whether or not a user has access to view daemon set detail by label selectors
+// HasJobAccess returns whether or not a user has access to view job detail by label selectors
 func (ra RoleAssignment) HasJobAccess(labels map[string]string) bool {
+	if ra.Fail {
+		return false
+	}
+	return true
+}
+
+// HasReplicaSetAccess returns whether or not a user has access to view replica set detail by label selectors
+func (ra RoleAssignment) HasReplicaSetAccess(labels map[string]string) bool {
 	if ra.Fail {
 		return false
 	}

--- a/api/auth/rbac/ra_operators_test.go
+++ b/api/auth/rbac/ra_operators_test.go
@@ -150,3 +150,21 @@ func TestHasJobAccess_Operators_HasAccess(t *testing.T) {
 
 	assert.True(t, result)
 }
+
+func TestHasReplicaSetAccess_Operators_HasAccess(t *testing.T) {
+	config.C.EnableRBAC = true
+	r := Role{
+		Operators:   true,
+		Viewers:     true,
+		MatchLabels: []string{"app=test"},
+		Exclusions:  []string{},
+	}
+	ra := RoleAssignment{r}
+
+	labels := make(map[string]string, 0)
+	labels["app"] = "test2"
+
+	result := ra.HasReplicaSetAccess(labels)
+
+	assert.True(t, result)
+}

--- a/api/auth/rbac/ra_viewers_test.go
+++ b/api/auth/rbac/ra_viewers_test.go
@@ -480,3 +480,57 @@ func TestHasJobAccess_Viewers_MatchedLabelHasAccess(t *testing.T) {
 
 	assert.True(t, result)
 }
+
+func TestHasReplicaSetAccess_Viewers_MissingMatchLabels(t *testing.T) {
+	config.C.EnableRBAC = true
+	r := Role{
+		Operators:   false,
+		Viewers:     true,
+		MatchLabels: []string{},
+		Exclusions:  []string{},
+	}
+	ra := RoleAssignment{r}
+
+	labels := make(map[string]string, 0)
+	labels["app"] = "test2"
+
+	result := ra.HasReplicaSetAccess(labels)
+
+	assert.False(t, result)
+}
+
+func TestHasReplicaSetAccess_Viewers_UnMatchedLabel(t *testing.T) {
+	config.C.EnableRBAC = true
+	r := Role{
+		Operators:   false,
+		Viewers:     true,
+		MatchLabels: []string{"app=test"},
+		Exclusions:  []string{},
+	}
+	ra := RoleAssignment{r}
+
+	labels := make(map[string]string, 0)
+	labels["app"] = "test2"
+
+	result := ra.HasReplicaSetAccess(labels)
+
+	assert.True(t, result)
+}
+
+func TestHasReplicaSetAccess_Viewers_MatchedLabelHasAccess(t *testing.T) {
+	config.C.EnableRBAC = true
+	r := Role{
+		Operators:   false,
+		Viewers:     true,
+		MatchLabels: []string{"app=test"},
+		Exclusions:  []string{},
+	}
+	ra := RoleAssignment{r}
+
+	labels := make(map[string]string, 0)
+	labels["app"] = "test"
+
+	result := ra.HasReplicaSetAccess(labels)
+
+	assert.True(t, result)
+}

--- a/api/auth/rbac/role_assignment.go
+++ b/api/auth/rbac/role_assignment.go
@@ -42,6 +42,8 @@ type RoleAssignmenter interface {
 	HasDaemonSetAccess(labels map[string]string) bool
 	// HasJobAccess returns whether or not a user has access to view job detail by label selectors
 	HasJobAccess(labels map[string]string) bool
+	// HasReplicaSetAccess returns whether or not a user has access to view replica set detail by label selectors
+	HasReplicaSetAccess(labels map[string]string) bool
 }
 
 /*RoleAssignment provides flags to indicate which features a user has access to.
@@ -193,8 +195,21 @@ func (ra RoleAssignment) HasDaemonSetAccess(labels map[string]string) bool {
 	return ra.CompareLabels(labels, false)
 }
 
-// HasJobAccess returns whether or not a user has access to view daemon set detail by label selectors
+// HasJobAccess returns whether or not a user has access to view job detail by label selectors
 func (ra RoleAssignment) HasJobAccess(labels map[string]string) bool {
+	if config.C.EnableRBAC {
+		if ra.Role.Viewers && !ra.Role.Operators {
+			// if not an operator, labels are required
+			if len(ra.Role.MatchLabels) == 0 {
+				return false
+			}
+		}
+	}
+	return ra.CompareLabels(labels, false)
+}
+
+// HasReplicaSetAccess returns whether or not a user has access to view replica set detail by label selectors
+func (ra RoleAssignment) HasReplicaSetAccess(labels map[string]string) bool {
 	if config.C.EnableRBAC {
 		if ra.Role.Viewers && !ra.Role.Operators {
 			// if not an operator, labels are required

--- a/api/k8sv1/client.go
+++ b/api/k8sv1/client.go
@@ -64,6 +64,10 @@ type Clienter interface {
 	JobOverviews(options JobOptions) (jobs []JobOverview, apiErr *errs.APIError)
 	// JobAppInfos returns basic info for all jobs found for a given namespace.
 	JobAppInfos(options JobOptions) (info []AppInfo, apiErr *errs.APIError)
+	// ReplicaSetOverviews returns a list of replica sets given filter options
+	ReplicaSetOverviews(options ReplicaSetOptions) (replicasets []ReplicaSetOverview, apiErr *errs.APIError)
+	// ReplicaSetAppInfos returns basic info for all replica sets found for a given namespace.
+	ReplicaSetAppInfos(options ReplicaSetOptions) (info []AppInfo, apiErr *errs.APIError)
 }
 
 // Client is the wrapper for kubernetes go client commands

--- a/api/k8sv1/fakes/k8v1_client.go
+++ b/api/k8sv1/fakes/k8v1_client.go
@@ -207,3 +207,29 @@ func (m *K8V1) JobAppInfos(options k8sv1.JobOptions) (info []k8sv1.AppInfo, apiE
 		},
 	}, nil
 }
+
+// ReplicaSetOverviews .
+func (m *K8V1) ReplicaSetOverviews(options k8sv1.ReplicaSetOptions) (replicasets []k8sv1.ReplicaSetOverview, apiErr *errs.APIError) {
+	if options.Namespace == "bad" {
+		return nil, errs.InternalServerError("JobOverviews Test Error")
+	}
+
+	return []k8sv1.ReplicaSetOverview{
+		k8sv1.ReplicaSetOverview{
+			Name: "job-name",
+		},
+	}, nil
+}
+
+// ReplicaSetAppInfos .
+func (m *K8V1) ReplicaSetAppInfos(options k8sv1.ReplicaSetOptions) (info []k8sv1.AppInfo, apiErr *errs.APIError) {
+	if options.Namespace == "bad" {
+		return nil, errs.InternalServerError("JobAppInfos Test Error")
+	}
+
+	return []k8sv1.AppInfo{
+		k8sv1.AppInfo{
+			Name: "rs-name",
+		},
+	}, nil
+}

--- a/api/k8sv1/pod.go
+++ b/api/k8sv1/pod.go
@@ -43,7 +43,7 @@ func (a *PodOverviewOptions) GetLimit() int64 {
 	if a.Limit > 0 {
 		return a.Limit
 	}
-	return 32
+	return 100
 }
 
 // UserCanAccess validates the user has access

--- a/api/k8sv1/replicaset.go
+++ b/api/k8sv1/replicaset.go
@@ -86,7 +86,7 @@ func (k *Client) ReplicaSetOverviews(options ReplicaSetOptions) (replicasets []R
 		wg.Add(len(list.Items))
 
 		for i, item := range list.Items {
-			if options.UserRole.HasDaemonSetAccess(item.GetLabels()) {
+			if options.UserRole.HasReplicaSetAccess(item.GetLabels()) {
 				go func(index int, rs appsv1.ReplicaSet) {
 					defer wg.Done()
 

--- a/api/k8sv1/replicaset.go
+++ b/api/k8sv1/replicaset.go
@@ -1,0 +1,228 @@
+package k8sv1
+
+import (
+	"sync"
+
+	"github.com/kubelens/kubelens/api/auth/rbac"
+	"github.com/kubelens/kubelens/api/errs"
+	klog "github.com/kubelens/kubelens/api/log"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ReplicaSetOptions contains fields used for filtering when retrieving daemon sets
+type ReplicaSetOptions struct {
+	// namespace to filter on
+	Namespace string `json:"namespace"`
+	// the label selector to match kinds
+	LabelSelector map[string]string `json:"labelSelector"`
+	//users role assignemnt
+	UserRole rbac.RoleAssignmenter
+	// logger instance
+	Logger klog.Logger
+}
+
+// ReplicaSetOverview .
+type ReplicaSetOverview struct {
+	// the name of the application
+	FriendlyName string `json:"friendlyName"`
+	// the name of the deployment
+	Name string `json:"name"`
+	// the namespace of the deployment
+	Namespace string `json:"namespace"`
+	// the label selector to match kinds
+	LabelSelector        map[string]string `json:"labelSelector"`
+	AvailableReplicas    int               `json:"availableReplicas"`
+	FullyLabeledReplicas int               `json:"fullyLabeledReplicas"`
+	ReadyReplicas        int               `json:"readyReplicas"`
+	Replicas             int               `json:"replicas"`
+	// represents the latest available observations of a deployment's current state.
+	Conditions          []appsv1.ReplicaSetCondition `json:"conditions"`
+	ConfigMaps          *[]v1.ConfigMap              `json:"configMaps,omitempty"`
+	DeploymentOverviews *[]DeploymentOverview        `json:"deploymentOverviews,omitempty"`
+}
+
+// AddConfigMaps sets the ConfigMaps value. Normally wouldn't have a pointer for a slice,
+// but this allows to easily return empty for the client.
+func (d *ReplicaSetOverview) AddConfigMaps(cms *[]v1.ConfigMap) {
+	d.ConfigMaps = cms
+}
+
+// AddDeploymentOverviews sets the DeploymentOverviews value. Adding separately for ease of
+// checking access before hand.
+func (d *ReplicaSetOverview) AddDeploymentOverviews(dp *[]DeploymentOverview) {
+	d.DeploymentOverviews = dp
+}
+
+// ReplicaSetOverviews returns a list of replicasets given filter options
+func (k *Client) ReplicaSetOverviews(options ReplicaSetOptions) (replicasets []ReplicaSetOverview, apiErr *errs.APIError) {
+	clientset, err := k.wrapper.GetClientSet()
+
+	if err != nil {
+		klog.Trace()
+		return nil, errs.InternalServerError(err.Error())
+	}
+
+	lo := metav1.ListOptions{
+		IncludeUninitialized: true,
+	}
+
+	if len(options.LabelSelector) > 0 {
+		lo.LabelSelector = toLabelSelectorString(options.LabelSelector)
+	}
+
+	list, err := clientset.AppsV1().ReplicaSets(options.Namespace).List(lo)
+
+	if err != nil {
+		klog.Trace()
+		return nil, errs.InternalServerError(err.Error())
+	}
+
+	if list != nil && len(list.Items) > 0 {
+		replicasets = make([]ReplicaSetOverview, len(list.Items))
+
+		wg := sync.WaitGroup{}
+		wg.Add(len(list.Items))
+
+		for i, item := range list.Items {
+			if options.UserRole.HasDaemonSetAccess(item.GetLabels()) {
+				go func(index int, rs appsv1.ReplicaSet) {
+					defer wg.Done()
+
+					var labelSelector map[string]string
+					// this shouldn't be null, but default to regular labels if it is.
+					if rs.Spec.Selector != nil {
+						labelSelector = rs.Spec.Selector.MatchLabels
+					} else if len(options.LabelSelector) > 0 {
+						labelSelector = options.LabelSelector
+					} else {
+						labelSelector = rs.GetLabels()
+					}
+
+					name := getFriendlyAppName(
+						rs.GetLabels(),
+						rs.GetName(),
+					)
+
+					rso := ReplicaSetOverview{
+						FriendlyName:         name,
+						Name:                 rs.GetName(),
+						Namespace:            rs.GetNamespace(),
+						LabelSelector:        labelSelector,
+						AvailableReplicas:    int(rs.Status.AvailableReplicas),
+						FullyLabeledReplicas: int(rs.Status.FullyLabeledReplicas),
+						ReadyReplicas:        int(rs.Status.ReadyReplicas),
+						Replicas:             int(rs.Status.Replicas),
+						Conditions:           rs.Status.Conditions,
+					}
+
+					// add deployments per daemon set for ease of display by client since deployments are really
+					// specific to certian K8s kinds.
+					if options.UserRole.HasDeploymentAccess(rs.GetLabels()) {
+						deployments, err := k.DeploymentOverviews(DeploymentOptions{
+							LabelSelector: labelSelector,
+							Namespace:     rs.GetNamespace(),
+							UserRole:      options.UserRole,
+							Logger:        options.Logger,
+						})
+						// just trace the error and move on, shouldn't be critical.
+						if err != nil {
+							klog.Trace()
+						}
+
+						if len(deployments) > 0 {
+							rso.AddDeploymentOverviews(&deployments)
+						}
+					}
+
+					if options.UserRole.HasConfigMapAccess(item.GetLabels()) {
+						cms, err := k.ConfigMaps(ConfigMapOptions{
+							Namespace:     rs.GetNamespace(),
+							LabelSelector: labelSelector,
+						})
+
+						// just trace the error and move on, shouldn't be critical.
+						if err != nil {
+							klog.Trace()
+						}
+
+						if len(cms) > 0 {
+							rso.AddConfigMaps(&cms)
+						}
+					}
+
+					replicasets[index] = rso
+				}(i, item)
+			}
+		}
+
+		wg.Wait()
+	}
+
+	return replicasets, nil
+}
+
+// ReplicaSetAppInfos returns basic info for all replica sets found for a given namespace.
+func (k *Client) ReplicaSetAppInfos(options ReplicaSetOptions) (info []AppInfo, apiErr *errs.APIError) {
+	clientset, err := k.wrapper.GetClientSet()
+
+	if err != nil {
+		klog.Trace()
+		return nil, errs.InternalServerError(err.Error())
+	}
+
+	list, err := clientset.AppsV1().ReplicaSets(options.Namespace).List(metav1.ListOptions{IncludeUninitialized: true})
+
+	if err != nil {
+		klog.Trace()
+		return nil, errs.InternalServerError(err.Error())
+	}
+
+	errors := []*errs.APIError{}
+
+	if list != nil {
+		info = make([]AppInfo, len(list.Items))
+
+		wg := sync.WaitGroup{}
+		wg.Add(len(list.Items))
+
+		for i, item := range list.Items {
+			go func(index int, rs appsv1.ReplicaSet) {
+				defer wg.Done()
+				if err != nil {
+					klog.Trace()
+					errors = append(errors, errs.InternalServerError(err.Error()))
+				}
+
+				var labelSelector map[string]string
+				// this shouldn't be null, but default to regular labels if it is.
+				if rs.Spec.Selector != nil {
+					labelSelector = rs.Spec.Selector.MatchLabels
+				} else {
+					labelSelector = rs.GetLabels()
+				}
+
+				name := getFriendlyAppName(
+					rs.GetLabels(),
+					rs.GetName(),
+				)
+
+				info[index] = AppInfo{
+					FriendlyName:  name,
+					Name:          rs.GetName(),
+					Namespace:     rs.GetNamespace(),
+					Kind:          "ReplicaSet",
+					LabelSelector: labelSelector,
+				}
+			}(i, item)
+		}
+		wg.Wait()
+	}
+
+	if len(errors) > 0 {
+		return info, errs.ListToInternalServerError(errors)
+	}
+
+	return info, nil
+}

--- a/api/k8sv1/replicaset_test.go
+++ b/api/k8sv1/replicaset_test.go
@@ -8,13 +8,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDaemonSetOverviewsDefaultSuccess(t *testing.T) {
+func TestReplicaSetOverviewsDefaultSuccess(t *testing.T) {
 	c := setupClient("testns", "test", false, false)
 
 	ls := map[string]string{}
 	ls[AppNameLabel] = FriendlyAppName
 
-	d, err := c.DaemonSetOverviews(DaemonSetOptions{
+	d, err := c.ReplicaSetOverviews(ReplicaSetOptions{
 		UserRole:      &rbacfakes.RoleAssignment{},
 		Logger:        &logfakes.Logger{},
 		Namespace:     "testns",
@@ -26,10 +26,10 @@ func TestDaemonSetOverviewsDefaultSuccess(t *testing.T) {
 	assert.Equal(t, d[0].Namespace, "testns")
 }
 
-func TestGetDaemonSetOverviewsDefaultFail(t *testing.T) {
+func TestGetReplicaSetOverviewsDefaultFail(t *testing.T) {
 	c := setupClient("testns", "test", true, true)
 
-	_, err := c.DaemonSetOverviews(DaemonSetOptions{
+	_, err := c.ReplicaSetOverviews(ReplicaSetOptions{
 		UserRole:      &rbacfakes.RoleAssignment{},
 		Logger:        &logfakes.Logger{},
 		Namespace:     "testns",
@@ -39,13 +39,13 @@ func TestGetDaemonSetOverviewsDefaultFail(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
-func TestDaemonSetAppInfosDefaultSuccess(t *testing.T) {
+func TestReplicaSetAppInfosDefaultSuccess(t *testing.T) {
 	c := setupClient("testns", "test", false, false)
 
 	ls := map[string]string{}
 	ls[AppNameLabel] = FriendlyAppName
 
-	d, err := c.DaemonSetAppInfos(DaemonSetOptions{
+	d, err := c.ReplicaSetAppInfos(ReplicaSetOptions{
 		UserRole:  &rbacfakes.RoleAssignment{},
 		Logger:    &logfakes.Logger{},
 		Namespace: "testns",
@@ -56,10 +56,10 @@ func TestDaemonSetAppInfosDefaultSuccess(t *testing.T) {
 	assert.Equal(t, d[0].Namespace, "testns")
 }
 
-func TestGetDaemonSetAppInfosDefaultFail(t *testing.T) {
+func TestGetReplicaSetAppInfosDefaultFail(t *testing.T) {
 	c := setupClient("testns", "test", true, true)
 
-	_, err := c.DaemonSetAppInfos(DaemonSetOptions{
+	_, err := c.ReplicaSetAppInfos(ReplicaSetOptions{
 		UserRole:  &rbacfakes.RoleAssignment{},
 		Logger:    &logfakes.Logger{},
 		Namespace: "testns",

--- a/web/src/areas/overview/index.tsx
+++ b/web/src/areas/overview/index.tsx
@@ -27,7 +27,8 @@ import ServiceOverviewPage from './service-view';
 import PodOverviewPage from './pod-view';
 import DaemonSetOverviewPage from './daemonset-view';
 import JobOverviewPage from './job-view';
-import { Service, PodOverview, DaemonSetOverview, JobOverview } from "../../types";
+import ReplicaSetOverviewPage from './replicaset-view';
+import { Service, PodOverview, DaemonSetOverview, JobOverview, ReplicaSetOverview } from "../../types";
 import { RouteComponentProps, withRouter } from 'react-router';
 import _ from 'lodash';
 import { IGlobalState } from '../../store';
@@ -46,7 +47,10 @@ type initialState = {
   dsConditionModalOpen: boolean,
   jobConfigMapModalOpen: boolean,
   jobDeploymentModalOpen: boolean,
-  jobConditionModalOpen: boolean
+  jobConditionModalOpen: boolean,
+  rsConfigMapModalOpen: boolean,
+  rsDeploymentModalOpen: boolean,
+  rsConditionModalOpen: boolean
 };
 
 export type OverviewProps = {
@@ -55,6 +59,7 @@ export type OverviewProps = {
   podOverview: PodOverview,
   daemonsetOverviews?: DaemonSetOverview[],
   jobOverviews?: JobOverview[],
+  replicasetOverviews?: ReplicaSetOverview[],
   selectedAppName: string,
   getAppOverview(appname: string, queryString: string): void,
   setSelectedAppName(value: string): void,
@@ -75,7 +80,10 @@ export class Overview extends Component<OverviewProps, initialState> {
     dsConditionModalOpen: false,
     jobConfigMapModalOpen: false,
     jobDeploymentModalOpen: false,
-    jobConditionModalOpen: false
+    jobConditionModalOpen: false,
+    rsConfigMapModalOpen: false,
+    rsDeploymentModalOpen: false,
+    rsConditionModalOpen: false
   }
 
   async componentDidMount() {
@@ -129,6 +137,15 @@ export class Overview extends Component<OverviewProps, initialState> {
       case 'job-configmap':
         this.setState({ jobConfigMapModalOpen: !this.state.jobConfigMapModalOpen});
         break;
+      case 'rs-condition':
+        this.setState({ rsConditionModalOpen: !this.state.rsConditionModalOpen});
+        break;
+      case 'rs-deployment':
+        this.setState({ rsDeploymentModalOpen: !this.state.rsDeploymentModalOpen});
+        break;
+      case 'rs-configmap':
+        this.setState({ rsConfigMapModalOpen: !this.state.rsConfigMapModalOpen});
+        break;
       default:
         break;
     }
@@ -159,6 +176,13 @@ export class Overview extends Component<OverviewProps, initialState> {
           configMapModalOpen={this.state.jobConfigMapModalOpen}
           deploymentModalOpen={this.state.jobDeploymentModalOpen} />
 
+        <ReplicaSetOverviewPage 
+          replicaSetOverviews={this.props.replicaSetOverviews} 
+          toggleModalType={this.toggleModalType}
+          conditionsModalOpen={this.state.rsConfigMapModalOpen}
+          configMapModalOpen={this.state.rsConfigMapModalOpen}
+          deploymentModalOpen={this.state.rsDeploymentModalOpen} />
+
         <PodOverviewPage podOverview={this.props.podOverview} />
 
         <APIErrorModal
@@ -177,7 +201,8 @@ export const mapStateToProps = ({ appsState, authState, clustersState, errorStat
   let serviceOverviews,
     daemonSetOverviews,
     jobOverviews,
-    podOverview;
+    podOverview,
+    replicaSetOverviews;
 
   if (appsState.appOverview && appsState.appOverview.serviceOverviews) {
     serviceOverviews = appsState.appOverview.serviceOverviews;
@@ -195,6 +220,10 @@ export const mapStateToProps = ({ appsState, authState, clustersState, errorStat
     podOverview = appsState.appOverview.podOverviews;
   }
 
+  if (appsState.appOverview && appsState.appOverview.replicaSetOverviews) {
+    replicaSetOverviews = appsState.appOverview.replicaSetOverviews;
+  }
+
   const overviewsEmpty = _.isEmpty(podOverview) && 
     (_.isEmpty(serviceOverviews) || _.isEmpty(daemonSetOverviews) || _.isEmpty(jobOverviews));
 
@@ -205,6 +234,7 @@ export const mapStateToProps = ({ appsState, authState, clustersState, errorStat
     daemonSetOverviews: daemonSetOverviews,
     jobOverviews: jobOverviews,
     podOverview: podOverview,
+    replicaSetOverviews: replicaSetOverviews,
     selectedAppName: appsState.selectedAppName,
     error: errorState,
     overviewsEmpty: overviewsEmpty

--- a/web/src/areas/overview/index.tsx
+++ b/web/src/areas/overview/index.tsx
@@ -57,9 +57,9 @@ export type OverviewProps = {
   identityToken?: string,
   serviceOverviews?: Service[],
   podOverview: PodOverview,
-  daemonsetOverviews?: DaemonSetOverview[],
+  daemonSetOverviews?: DaemonSetOverview[],
   jobOverviews?: JobOverview[],
-  replicasetOverviews?: ReplicaSetOverview[],
+  replicaSetOverviews?: ReplicaSetOverview[],
   selectedAppName: string,
   getAppOverview(appname: string, queryString: string): void,
   setSelectedAppName(value: string): void,
@@ -225,7 +225,7 @@ export const mapStateToProps = ({ appsState, authState, clustersState, errorStat
   }
 
   const overviewsEmpty = _.isEmpty(podOverview) && 
-    (_.isEmpty(serviceOverviews) || _.isEmpty(daemonSetOverviews) || _.isEmpty(jobOverviews));
+    (_.isEmpty(serviceOverviews) || _.isEmpty(daemonSetOverviews) || _.isEmpty(jobOverviews) || _.isEmpty(replicaSetOverviews));
 
   return {
     cluster: clustersState.cluster,

--- a/web/src/areas/overview/replicaset-view.spec.tsx
+++ b/web/src/areas/overview/replicaset-view.spec.tsx
@@ -1,0 +1,102 @@
+import React from 'react'
+import Enzyme, { shallow } from 'enzyme'
+import Adapter from 'enzyme-adapter-react-16'
+import ReplicaSetViewPage from './replicaset-view'
+
+Enzyme.configure({ adapter: new Adapter() })
+
+const setup = () => {
+  const props = {
+    replicaSetOverviews: [{
+      friendlyName: 'fname',
+      name: 'name',
+      namespace: 'namespace',
+      labelSelector: {
+        key: 'value'
+      },
+      availableReplicas: 1,
+      fullyLabeledReplicas: 1,
+      readyReplicas: 1,
+      replicas: 1,
+      conditions: [{
+        name: 'name'
+      }],
+      configMaps: [{
+        name: 'name'
+      }],
+      deploymentOverviews: [{
+        friendlyName: 'fname',
+        name: 'name',
+        namespace: 'namespace',
+        labelSelector: {
+          key: 'value'
+        },
+        replicas: 1,
+        updatedReplicas: 1,
+        readyReplicas: 1,
+        unavailableReplicas: 1,
+        conditions: [{
+          name: 'test'
+        }]
+      }]
+    }],
+    toggleModalType: jest.fn(),
+    conditionsModalOpen: false,
+    configMapModalOpen: false,
+    deploymentModalOpen: false
+  }
+
+  const wrapper = shallow(<ReplicaSetViewPage {...props} />)
+
+  return {
+    props,
+    wrapper
+  }
+}
+
+describe('replica set overview should', () => {
+  test('render with a replicaOverviews', () => {
+    const { wrapper } = setup();
+
+    expect(wrapper.find('Card').length).toBe(1);
+  })
+
+  test('have job info displayed', () => {
+    const { wrapper } = setup();
+
+    expect(wrapper.findWhere(n => n.prop('label') === 'Replicas').length).toBe(1);
+    expect(wrapper.findWhere(n => n.prop('label') === 'Ready Replicas').length).toBe(1);
+    expect(wrapper.findWhere(n => n.prop('label') === 'Available').length).toBe(1);
+    expect(wrapper.findWhere(n => n.prop('label') === 'Fully Labeled').length).toBe(1);
+  })
+
+  test('have Deployments button displayed', () => {
+    const { wrapper } = setup();
+
+    expect(wrapper.find('Button').findWhere(n => n.text() === 'Deployments').length).toBe(1);
+  })
+
+  test('have ConfigMaps button displayed', () => {
+    const { wrapper } = setup();
+
+    expect(wrapper.find('Button').findWhere(n => n.text() === 'ConfigMaps').length).toBe(1);
+  })
+
+  test('have Conditions button displayed', () => {
+    const { wrapper } = setup();
+
+    expect(wrapper.find('Button').findWhere(n => n.text() === 'Conditions').length).toBe(1);
+  })
+
+  test('have CardFooter (pod conditions) displayed', () => {
+    const { wrapper } = setup();
+
+    expect(wrapper.find('CardFooter').length).toBe(1);
+  })
+
+  test('have JsonViewModals defined', () => {
+    const { wrapper } = setup();
+
+    expect(wrapper.find('JsonViewModal').length).toBe(3);
+  })
+})

--- a/web/src/areas/overview/replicaset-view.tsx
+++ b/web/src/areas/overview/replicaset-view.tsx
@@ -1,0 +1,137 @@
+/*
+MIT License
+
+Copyright (c) 2020 The KubeLens Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+import React from 'react';
+import { Row, Col, Card, CardBody, CardFooter, Button } from 'reactstrap';
+import CardText from '../../components/text';
+import JsonViewModal from '../../components/json-view-modal';
+import { ReplicaSetOverview } from '../../types';
+import DeploymentOverviews from '../../components/deployment-overviews';
+import _ from 'lodash';
+
+export type ReplicaSetOverviewProps = {
+  replicaSetOverviews: ReplicaSetOverview[],
+  toggleModalType: (type: string) => void,
+  conditionsModalOpen: boolean,
+  configMapModalOpen: boolean,
+  deploymentModalOpen: boolean
+};
+
+const DaemonSetView = ({
+  replicaSetOverviews,
+  toggleModalType,
+  conditionsModalOpen,
+  configMapModalOpen,
+  deploymentModalOpen
+}: ReplicaSetOverviewProps) => {
+  return (
+    <div>
+      {!_.isEmpty(replicaSetOverviews) &&
+        <span>
+          <h4>DaemonSet</h4>
+          <hr />
+        </span>
+      }
+      {!_.isEmpty(replicaSetOverviews) && replicaSetOverviews.map((overview: ReplicaSetOverview) => {
+      return (
+      <div key={overview.name}>
+        <Card className="kind-detail-container mb-4">
+          <CardBody>
+            <small>
+              <Row>
+                <Col sm={!_.isEmpty(overview.conditions) || !_.isEmpty(overview.deploymentOverviews) ||!_.isEmpty(overview.configMaps) ? 7 : 12}>
+                  <Row>
+                    <Col sm={3}>
+                      <CardText label="Replicas" value={overview.replicas} />
+                    </Col>
+                    <Col sm={3}>
+                      <CardText label="Ready Replicas" value={overview.readyReplicas} />
+                    </Col>
+                    <Col sm={3}>
+                      <CardText label="Available" value={overview.availableReplicas} />
+                    </Col>
+                    <Col sm={3}>
+                      <CardText label="Fully Labeled" value={overview.fullyLabeledReplicas} />
+                    </Col>
+                  </Row>
+                </Col>
+                {!_.isEmpty(overview.conditions) || !_.isEmpty(overview.deploymentOverviews) ||!_.isEmpty(overview.configMaps)
+                ? <Col sm={5}>
+                  <Row>
+                    <Col sm={6}>
+                      {!_.isEmpty(overview.conditions)
+                      ? <Button outline color="info" onClick={() => toggleModalType('ds-condition')} block>Conditions</Button>
+                      : null}
+                    </Col>
+                    <Col sm={6}>
+                      {!_.isEmpty(overview.deploymentOverviews)
+                      ? <Button outline color="info" onClick={() => toggleModalType('ds-deployment')} block>Deployments</Button>
+                      : null}
+                      {!_.isEmpty(overview.configMaps)
+                      ? <Button outline color="info" onClick={() => toggleModalType('ds-configMap')} block>ConfigMaps</Button>
+                      : null}
+                    </Col>
+                  </Row>
+                </Col>
+                : null}
+              </Row>
+            </small>
+          </CardBody>
+          {!_.isEmpty(overview.deploymentOverviews) ?
+            <CardFooter>
+              <DeploymentOverviews overviews={overview.deploymentOverviews} keyPrefix={`ds-${overview.name}`} />
+            </CardFooter>
+          : null
+          }
+        </Card>
+
+        <JsonViewModal
+          title="Conditions"
+          show={conditionsModalOpen}
+          body={overview.conditions}
+          handleClose={() => {
+            toggleModalType('ds-condition');
+          }} />
+    
+        <JsonViewModal
+          title="ConfigMaps"
+          show={configMapModalOpen}
+          body={overview.configMaps}
+          handleClose={() => {
+            toggleModalType('ds-configMap');
+          }} />
+
+        <JsonViewModal
+          title="Deployments"
+          show={deploymentModalOpen}
+          body={overview.deploymentOverviews}
+          handleClose={() => {
+            toggleModalType('ds-deployment');
+          }} />
+      </div>
+    )})}
+  </div>
+  );
+};
+
+export default DaemonSetView;

--- a/web/src/areas/overview/replicaset-view.tsx
+++ b/web/src/areas/overview/replicaset-view.tsx
@@ -37,7 +37,7 @@ export type ReplicaSetOverviewProps = {
   deploymentModalOpen: boolean
 };
 
-const DaemonSetView = ({
+const ReplicaSetView = ({
   replicaSetOverviews,
   toggleModalType,
   conditionsModalOpen,
@@ -48,7 +48,7 @@ const DaemonSetView = ({
     <div>
       {!_.isEmpty(replicaSetOverviews) &&
         <span>
-          <h4>DaemonSet</h4>
+          <h4>ReplicaSet</h4>
           <hr />
         </span>
       }
@@ -80,15 +80,15 @@ const DaemonSetView = ({
                   <Row>
                     <Col sm={6}>
                       {!_.isEmpty(overview.conditions)
-                      ? <Button outline color="info" onClick={() => toggleModalType('ds-condition')} block>Conditions</Button>
+                      ? <Button outline color="info" onClick={() => toggleModalType('rs-condition')} block>Conditions</Button>
                       : null}
                     </Col>
                     <Col sm={6}>
                       {!_.isEmpty(overview.deploymentOverviews)
-                      ? <Button outline color="info" onClick={() => toggleModalType('ds-deployment')} block>Deployments</Button>
+                      ? <Button outline color="info" onClick={() => toggleModalType('rs-deployment')} block>Deployments</Button>
                       : null}
                       {!_.isEmpty(overview.configMaps)
-                      ? <Button outline color="info" onClick={() => toggleModalType('ds-configMap')} block>ConfigMaps</Button>
+                      ? <Button outline color="info" onClick={() => toggleModalType('rs-configMap')} block>ConfigMaps</Button>
                       : null}
                     </Col>
                   </Row>
@@ -110,7 +110,7 @@ const DaemonSetView = ({
           show={conditionsModalOpen}
           body={overview.conditions}
           handleClose={() => {
-            toggleModalType('ds-condition');
+            toggleModalType('rs-condition');
           }} />
     
         <JsonViewModal
@@ -118,7 +118,7 @@ const DaemonSetView = ({
           show={configMapModalOpen}
           body={overview.configMaps}
           handleClose={() => {
-            toggleModalType('ds-configMap');
+            toggleModalType('rs-configMap');
           }} />
 
         <JsonViewModal
@@ -126,7 +126,7 @@ const DaemonSetView = ({
           show={deploymentModalOpen}
           body={overview.deploymentOverviews}
           handleClose={() => {
-            toggleModalType('ds-deployment');
+            toggleModalType('rs-deployment');
           }} />
       </div>
     )})}
@@ -134,4 +134,4 @@ const DaemonSetView = ({
   );
 };
 
-export default DaemonSetView;
+export default ReplicaSetView;

--- a/web/src/config/config.json
+++ b/web/src/config/config.json
@@ -1,17 +1,18 @@
 {
-  "oAuthJwtIssuer": "https://YOUR_DOMAIN.oktapreview.com/oauth2/YOUR_TENANT",
-  "oAuthAudience": "auth://YOUR_DOMAIN.com",
-  "oAuthClientId": "CLIENT_ID",
-  "oAuthRedirectUri": "http://localhost:3000",
-  "oAuthResponseType": "id_token token",
-  "oAuthRequestType": "Bearer",
-  "oAuthScope": "openid profile email",
-  "oAuthConnection": "adfs",
-  "oAuthEnabled": false,
   "availableClusters": [
     {
-      "minikube": "http://api.kubelens.local"
+      "NonProd2 - CentralUS": "http://kubelens-api.kubelens.centralus-ds-aks-np2.centralus.chrazure.cloud"
     }
   ],
-  "deployerLinkName": "Octopus Link"
+  "oAuthJwtIssuer": "",
+  "oAuthAudience": "",
+  "oAuthClientId": "",
+  "oAuthRedirectUri": "",
+  "oAuthResponseType": "",
+  "oAuthRequestType": "",
+  "oAuthScope": "",
+  "oAuthProvider": "",
+  "oAuthConnection": "",
+  "oAuthEnabled": false,
+  "deployerLinkName": ""
 }

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -58,6 +58,7 @@ export type Apps = App[];
 export type AppOverview = {
   serviceOverviews: Service[],
   daemonSetOverviews: DaemonSetOverview[],
+  replicaSetOverviews: ReplicaSetOverview[],
   jobOverviews: JobOverview[],
   podOverviews: PodOverview
 }
@@ -180,6 +181,20 @@ export type JobOverview = {
 	active: number,
 	succeeded: number,
 	failed: number,
+  conditions: [],
+  configMaps?: [{}],
+  deploymentOverviews?: DeploymentOverview[]
+}
+
+export type ReplicaSetOverview = {
+  friendlyName: string,
+  name: string,
+  namespace: string,
+  labelSelector: {},
+  availableReplicas: number,
+  fullyLabeledReplicas: number,
+  readyReplicas: number,
+  replicas: number,
   conditions: [],
   configMaps?: [{}],
   deploymentOverviews?: DeploymentOverview[]


### PR DESCRIPTION
Signed-Off-By: Travis Schoenberg <traviisd@gmail.com>

__What this PR does:__

Adds retrieval of ReplicaSet objects. Also fixes the missing display overview for Job objects that were not being returned from the API when "overviews" were requested.

__Which issue(s) this PR fixes:__

Fixes #

__Does this PR introduce a user-facing change?:__

Yes, addition of ReplicaSet view
