### PR TITLE
Web & API - Return Replicas > 0 Desired

### DIFF
--- a/api/k8sv1/daemonset.go
+++ b/api/k8sv1/daemonset.go
@@ -196,10 +196,6 @@ func (k *Client) DaemonSetAppInfos(options DaemonSetOptions) (info []AppInfo, ap
 		for i, item := range list.Items {
 			go func(index int, ds appsv1.DaemonSet) {
 				defer wg.Done()
-				if err != nil {
-					klog.Trace()
-					errors = append(errors, errs.InternalServerError(err.Error()))
-				}
 
 				var labelSelector map[string]string
 				// this shouldn't be null, but default to regular labels if it is.

--- a/api/k8sv1/replicaset.go
+++ b/api/k8sv1/replicaset.go
@@ -1,6 +1,7 @@
 package k8sv1
 
 import (
+	"strings"
 	"sync"
 
 	"github.com/kubelens/kubelens/api/auth/rbac"
@@ -163,7 +164,14 @@ func (k *Client) ReplicaSetOverviews(options ReplicaSetOptions) (replicasets []R
 		wg.Wait()
 	}
 
-	return replicasets, nil
+	ret := []ReplicaSetOverview{}
+	for _, rs := range replicasets {
+		if !strings.EqualFold(rs.Name, "") {
+			ret = append(ret, rs)
+		}
+	}
+
+	return ret, nil
 }
 
 // ReplicaSetAppInfos returns basic info for all replica sets found for a given namespace.
@@ -226,5 +234,13 @@ func (k *Client) ReplicaSetAppInfos(options ReplicaSetOptions) (info []AppInfo, 
 		return info, errs.ListToInternalServerError(errors)
 	}
 
-	return info, nil
+	// remove blanks
+	ret := []AppInfo{}
+	for _, app := range info {
+		if !strings.EqualFold(app.Name, "") {
+			ret = append(ret, app)
+		}
+	}
+
+	return ret, nil
 }

--- a/api/k8sv1/wrapper_test.go
+++ b/api/k8sv1/wrapper_test.go
@@ -269,6 +269,8 @@ func (m *mockWrapper) GetClientSet() (clientset kubernetes.Interface, err error)
 
 		// Inject an event into the fake client.
 		rs := &appsv1.ReplicaSet{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, Labels: lbl}}
+		specReplicas := int32(1)
+		rs.Spec.Replicas = &specReplicas
 		_, err = client.AppsV1().ReplicaSets(namespace).Create(rs)
 		if err != nil {
 			return nil, err

--- a/api/k8sv1/wrapper_test.go
+++ b/api/k8sv1/wrapper_test.go
@@ -185,6 +185,8 @@ func (m *mockWrapper) GetClientSet() (clientset kubernetes.Interface, err error)
 			s.Spec.Selector = &metav1.LabelSelector{
 				MatchLabels: lbl,
 			}
+			replicas := int32(1)
+			s.Spec.Replicas = &replicas
 			fmt.Printf("replicaset added: %s\n", s.Name)
 			replicaset <- s
 			cancel()

--- a/web/src/actions/apps.ts
+++ b/web/src/actions/apps.ts
@@ -54,7 +54,7 @@ export interface IGetAppOverview {
 <Promise<Return Type>, State Interface, Type of Param, Type of Action> */
 export const getAppOverview: ActionCreator<
   ThunkAction<Promise<any>, IAppsState, null, IGetAppOverview>
-> = (appname: string, labelSelector: string, cluster: string, jwt: string) => {
+> = (appname: string, namespace: string, labelSelector: string, cluster: string, jwt: string) => {
   return async (dispatch: Dispatch) => {
     try {
       dispatch({
@@ -62,7 +62,7 @@ export const getAppOverview: ActionCreator<
         loading: true,
       });
 
-      const response = await adapter.get(`/apps/${appname}?labelSelector=${encodeURIComponent(labelSelector)}&detailed=true`, cluster, jwt);
+      const response = await adapter.get(`/apps/${appname}?namespace=${namespace}&labelSelector=${encodeURIComponent(labelSelector)}&detailed=true`, cluster, jwt);
 
       dispatch({
         type: AppsActionTypes.GET_APP_OVERVIEW,

--- a/web/src/areas/home/index.tsx
+++ b/web/src/areas/home/index.tsx
@@ -43,7 +43,7 @@ export type HomeProps = {
   filteredApps: App[],
   apps: App[],
   getApps(cluster: string, jwt: string): void,
-  getAppOverview(appname: string, queryString: string, cluster: string, jwt: string): void,
+  getAppOverview(appname: string, namespace: string, queryString: string, cluster: string, jwt: string): void,
   setSelectedAppName(value: string): void,
   filterApps(value: string, apps: App[]): void,
   error: IErrorState,
@@ -86,12 +86,12 @@ export class Home extends Component<HomeProps, initialState> {
     this.props.filterApps(event.target.value, this.props.apps);
   }
 
-  private onViewApp(appname: string, labelSelector: string) {
+  private onViewApp(appname: string, namespace: string, labelSelector: string) {
     this.props.setSelectedAppName(labelSelector);
 
-    this.props.getAppOverview(appname, labelSelector, this.props.cluster, this.props.identityToken);
+    this.props.getAppOverview(appname, namespace, labelSelector, this.props.cluster, this.props.identityToken);
 
-    this.props.history.push(`/${appname}?labelSelector=${encodeURIComponent(labelSelector)}`);
+    this.props.history.push(`/${appname}?namespace=${namespace}&labelSelector=${encodeURIComponent(labelSelector)}`);
   }
 
   public render() {
@@ -129,7 +129,7 @@ export const mapStateToProps = ({ loadingState, appsState, authState, clustersSt
 export const mapActionsToProps = (dispatch) => {
   return {
     getApps: (cluster: string, jwt: string) => dispatch(getApps(cluster, jwt)),
-    getAppOverview: (appname: string, queryString: string, cluster: string, jwt: string) => dispatch(getAppOverview(appname, queryString, cluster, jwt)),
+    getAppOverview: (appname: string, namespace: string, queryString: string, cluster: string, jwt: string) => dispatch(getAppOverview(appname, namespace, queryString, cluster, jwt)),
     setSelectedAppName: (value: string) => dispatch(setSelectedAppName(value)),
     filterApps: (value: string, apps: App[]) => dispatch(filterApps(value, apps)),
     closeErrorModal: () => dispatch(closeErrorModal())

--- a/web/src/areas/home/view.tsx
+++ b/web/src/areas/home/view.tsx
@@ -38,7 +38,7 @@ export type HomeViewProps =
     appName?: string
   }>> & {
     onFilterChanged: Function,
-    onViewApp(appname: string, labelSelector: string),
+    onViewApp(appname: string, namespace: string, labelSelector: string),
     filteredApps: App[],
     selectedAppName: string
   }
@@ -65,9 +65,9 @@ const HomePage = (props: HomeViewProps) => {
           {/* I don't understand css enough to get this to work without inline style, moving on. */}
           <div dir="rtl" style={{ maxHeight: '76vh', overflow: 'scroll', marginRight: -40, paddingRight: 40 }}>
             {filteredApps && filteredApps.map((value: any, index: number) => {
-              const svc = value as App;
+              const app = value as App;
               const viewApp = () => {
-                return onViewApp(svc.name, svc.labelSelector);
+                return onViewApp(app.name, app.namespace, app.labelSelector);
               };
               // if from a link, grab the name of the app so we can mark which one is being viewed.
               const selected =
@@ -76,12 +76,12 @@ const HomePage = (props: HomeViewProps) => {
                   : selectedAppName;
 
               return (
-                <div key={`${svc.name}-${index}`} id="anti-shadow-div">
+                <div key={`${app.name}-${index}`} id="anti-shadow-div">
                   <div id="shadow-div" >
-                    <Card dir="ltr" style={{ marginRight: (svc.labelSelector === selected) ? -40 : 0, marginBottom: '10px', border: '3px solid #4D5061' }}>
+                    <Card dir="ltr" style={{ marginRight: (app.labelSelector === selected) ? -40 : 0, marginBottom: '10px', border: '3px solid #4D5061' }}>
                       <CardHeader className="text-center" style={{ backgroundColor: 'white' }}>
                         <strong>
-                          {svc.name}
+                          {app.name}
                         </strong>
                       </CardHeader>
                       <CardBody>
@@ -89,16 +89,16 @@ const HomePage = (props: HomeViewProps) => {
                           <Col sm={10}>
                             <div>
                               <div className="app-list-text-root">
-                                <small>Namespace: <strong>{svc.namespace}</strong></small>
+                                <small>Namespace: <strong>{app.namespace}</strong></small>
                               </div>
                               <div className="app-list-text-root">
-                                <small>Kind: <strong>{svc.kind}</strong></small>
+                                <small>Kind: <strong>{app.kind}</strong></small>
                               </div>
                               <div className="app-list-text-secondary">
                                 <small>
                                   {
-                                    svc.deployerLink
-                                      ? <a href={svc.deployerLink} target="_blank" rel="noopener noreferrer"><strong>Deployer Link</strong></a>
+                                    app.deployerLink
+                                      ? <a href={app.deployerLink} target="_blank" rel="noopener noreferrer"><strong>Deployer Link</strong></a>
                                       : <em>No Deployer Link</em>
                                   }
                                 </small>


### PR DESCRIPTION
__What this PR does:__

Removes ReplicaSets that have 0 desired to remove clutter returned from the API and displayed in the UI.

__Which issue(s) this PR fixes:__

Fixes #

__Does this PR introduce a user-facing change?:__

Yes, adds the namespace to the App Overviews query string to reduce results to the selected app by namespace.