### PR TITLE
API - Selector or labels match for deployments & config maps

### DIFF
--- a/api/k8sv1/deployment.go
+++ b/api/k8sv1/deployment.go
@@ -72,7 +72,7 @@ func (k *Client) DeploymentOverviews(options DeploymentOptions) (deployments []D
 		for _, item := range list.Items {
 			deploymentLabels := item.GetLabels()
 
-			if options.UserRole.HasDeploymentAccess(deploymentLabels) && labelsContainSelector(options.LabelSelector, deploymentLabels) {
+			if options.UserRole.HasDeploymentAccess(deploymentLabels) {
 				var labelSelector map[string]string
 				// this shouldn't be null, but default to regular labels if it is.
 				if item.Spec.Selector != nil {
@@ -83,24 +83,26 @@ func (k *Client) DeploymentOverviews(options DeploymentOptions) (deployments []D
 					labelSelector = deploymentLabels
 				}
 
-				name := getFriendlyAppName(
-					deploymentLabels,
-					item.GetName(),
-				)
+				if labelsContainSelector(options.LabelSelector, labelSelector) {
+					name := getFriendlyAppName(
+						deploymentLabels,
+						item.GetName(),
+					)
 
-				deployments = append(deployments, DeploymentOverview{
-					FriendlyName:         name,
-					Name:                 item.GetName(),
-					Namespace:            item.GetNamespace(),
-					LabelSelector:        labelSelector,
-					ResourceVersion:      item.GetResourceVersion(),
-					AvailableReplicas:    int(item.Status.AvailableReplicas),
-					ReadyReplicas:        int(item.Status.ReadyReplicas),
-					Replicas:             int(item.Status.Replicas),
-					UnavailableReplicas:  int(item.Status.UnavailableReplicas),
-					UpdatedReplicas:      int(item.Status.UnavailableReplicas),
-					DeploymentConditions: item.Status.Conditions,
-				})
+					deployments = append(deployments, DeploymentOverview{
+						FriendlyName:         name,
+						Name:                 item.GetName(),
+						Namespace:            item.GetNamespace(),
+						LabelSelector:        labelSelector,
+						ResourceVersion:      item.GetResourceVersion(),
+						AvailableReplicas:    int(item.Status.AvailableReplicas),
+						ReadyReplicas:        int(item.Status.ReadyReplicas),
+						Replicas:             int(item.Status.Replicas),
+						UnavailableReplicas:  int(item.Status.UnavailableReplicas),
+						UpdatedReplicas:      int(item.Status.UnavailableReplicas),
+						DeploymentConditions: item.Status.Conditions,
+					})
+				}
 			}
 		}
 	}

--- a/api/k8sv1/replicaset.go
+++ b/api/k8sv1/replicaset.go
@@ -122,37 +122,35 @@ func (k *Client) ReplicaSetOverviews(options ReplicaSetOptions) (replicasets []R
 
 						// add deployments per daemon set for ease of display by client since deployments are really
 						// specific to certian K8s kinds.
-						if options.UserRole.HasDeploymentAccess(rs.GetLabels()) {
-							deployments, err := k.DeploymentOverviews(DeploymentOptions{
-								LabelSelector: labelSelector,
-								Namespace:     rs.GetNamespace(),
-								UserRole:      options.UserRole,
-								Logger:        options.Logger,
-							})
-							// just trace the error and move on, shouldn't be critical.
-							if err != nil {
-								klog.Trace()
-							}
-
-							if len(deployments) > 0 {
-								rso.AddDeploymentOverviews(&deployments)
-							}
+						deployments, err := k.DeploymentOverviews(DeploymentOptions{
+							LabelSelector: labelSelector,
+							Namespace:     rs.GetNamespace(),
+							UserRole:      options.UserRole,
+							Logger:        options.Logger,
+						})
+						// just trace the error and move on, shouldn't be critical.
+						if err != nil {
+							klog.Trace()
 						}
 
-						if options.UserRole.HasConfigMapAccess(item.GetLabels()) {
-							cms, err := k.ConfigMaps(ConfigMapOptions{
-								Namespace:     rs.GetNamespace(),
-								LabelSelector: labelSelector,
-							})
+						if len(deployments) > 0 {
+							rso.AddDeploymentOverviews(&deployments)
+						}
 
-							// just trace the error and move on, shouldn't be critical.
-							if err != nil {
-								klog.Trace()
-							}
+						cms, err := k.ConfigMaps(ConfigMapOptions{
+							Namespace:     rs.GetNamespace(),
+							LabelSelector: labelSelector,
+							Logger:        options.Logger,
+							UserRole:      options.UserRole,
+						})
 
-							if len(cms) > 0 {
-								rso.AddConfigMaps(&cms)
-							}
+						// just trace the error and move on, shouldn't be critical.
+						if err != nil {
+							klog.Trace()
+						}
+
+						if len(cms) > 0 {
+							rso.AddConfigMaps(&cms)
 						}
 
 						replicasets[index] = rso
@@ -165,9 +163,9 @@ func (k *Client) ReplicaSetOverviews(options ReplicaSetOptions) (replicasets []R
 	}
 
 	ret := []ReplicaSetOverview{}
-	for _, rs := range replicasets {
-		if !strings.EqualFold(rs.Name, "") {
-			ret = append(ret, rs)
+	for _, item := range replicasets {
+		if len(item.Name) > 0 {
+			ret = append(ret, item)
 		}
 	}
 

--- a/api/k8sv1/util.go
+++ b/api/k8sv1/util.go
@@ -26,6 +26,7 @@ package k8sv1
 
 import (
 	"fmt"
+	"reflect"
 	"regexp"
 	"strings"
 
@@ -71,4 +72,27 @@ func toLabelSelectorString(labelSelector map[string]string) (labelSelectorString
 		labelSelectorString += fmt.Sprintf("%s=%s,", k, v)
 	}
 	return strings.TrimSuffix(labelSelectorString, ",")
+}
+
+func labelsContainSelector(selector map[string]string, labels map[string]string) bool {
+	if len(labels) == 0 {
+		return false
+	}
+
+	// shortcut if exact
+	if reflect.DeepEqual(selector, labels) {
+		return true
+	}
+
+	if len(selector) > 0 {
+		for labelKey, labelValue := range labels {
+			if len(selector[labelKey]) > 0 && strings.EqualFold(selector[labelKey], labelValue) {
+				return true
+			}
+		}
+		return false
+	}
+	
+	// default to true if no labels are provided to allow all
+	return true
 }

--- a/api/k8sv1/util_test.go
+++ b/api/k8sv1/util_test.go
@@ -48,3 +48,69 @@ func TestGetFriendlyAppNameMatchedt(t *testing.T) {
 	n := getFriendlyAppName(l, "auto-generated-name-1234")
 	assert.Equal(t, "real-app-name", n)
 }
+
+func TestLabelsContainSelectorTrue(t *testing.T) {
+	selector := map[string]string{
+		"app":          "app-name",
+		"pod-template": "1234adsf1A",
+	}
+	labels := map[string]string{
+		"app": "app-name",
+	}
+
+	match := labelsContainSelector(selector, labels)
+
+	assert.True(t, match)
+}
+
+func TestLabelsContainSelectorFalse(t *testing.T) {
+	selector := map[string]string{
+		"app":          "app-name2",
+		"pod-template": "1234adsf1A",
+	}
+	labels := map[string]string{
+		"app": "app-name",
+	}
+
+	match := labelsContainSelector(selector, labels)
+
+	assert.False(t, match)
+}
+
+func TestLabelsContainSelectorNilLabels(t *testing.T) {
+	selector := map[string]string{
+		"app":          "app-name",
+		"pod-template": "1234adsf1A",
+	}
+
+	match := labelsContainSelector(selector, nil)
+
+	assert.False(t, match)
+}
+
+func TestLabelsContainSelectorDeepEqualTrue(t *testing.T) {
+	selector := map[string]string{
+		"app":          "app-name",
+		"pod-template": "1234adsf1A",
+	}
+
+	labels := map[string]string{
+		"app":          "app-name",
+		"pod-template": "1234adsf1A",
+	}
+
+	match := labelsContainSelector(selector, labels)
+
+	assert.True(t, match)
+}
+
+func TestLabelsContainSelectorNoSelector(t *testing.T) {
+	labels := map[string]string{
+		"app":          "app-name",
+		"pod-template": "1234adsf1B",
+	}
+
+	match := labelsContainSelector(nil, labels)
+
+	assert.True(t, match)
+}


### PR DESCRIPTION
__What this PR does:__

Fixes the issue where Deployment & ConfigMap objects are not matched when selectors are not exact.

__Which issue(s) this PR fixes:__

Fixes #50 

__Does this PR introduce a user-facing change?:__

No. Items will just show up now that they can be returned.