### PR TITLE
API - Fix auth bug when matching labels

### DIFF
--- a/api/auth/rbac/role.go
+++ b/api/auth/rbac/role.go
@@ -97,8 +97,10 @@ func (r Role) CompareLabels(labels map[string]string, exact bool) bool {
 				lblParts := strings.Split(mlbl, "=")
 				// find a matching label and return found to grant access
 				if value, ok := labels[lblParts[0]]; ok && !r.InExclusions(value) {
-					// if exact, must match the label value as well (application name typically).
-					if exact {
+					// if exact, must match the label value as well (application name typically),
+					// if the value is null, allow access as it's assumed that the match pattern
+					// would be more generic, e.g. "app" vs "app=*".
+					if exact && len(lblParts) > 1 {
 						if strings.EqualFold(value, lblParts[1]) {
 							canAccess = true
 						}


### PR DESCRIPTION
Signed-Off-By: Travis Schoenberg <traviisd@gmail.com>

__What this PR does:__

Fixes an issue with auth when matching labels to grant access on an exact label match.

__Which issue(s) this PR fixes:__

Fixes #53 

__Does this PR introduce a user-facing change?:__

No