### PR TITLE
Removing redundant ReplicaSet from Apps list

### DIFF
--- a/api/k8sv1/apps.go
+++ b/api/k8sv1/apps.go
@@ -97,8 +97,8 @@ func (k *Client) Apps(options AppOptions) (apps []App, apiErr *errs.APIError) {
 		appInfos := []*[]AppInfo{}
 
 		wg := sync.WaitGroup{}
-		// adding 3x since we are using 4 go routines per iteration
-		wg.Add(len(namespaces.Items) * 4)
+		// adding 3x since we are using 3 go routines per iteration
+		wg.Add(len(namespaces.Items) * 3)
 
 		errors := []*errs.APIError{}
 
@@ -138,20 +138,6 @@ func (k *Client) Apps(options AppOptions) (apps []App, apiErr *errs.APIError) {
 				defer wg.Done()
 
 				jobInfos, err := k.JobAppInfos(JobOptions{Namespace: namespace})
-
-				if err != nil {
-					klog.Trace()
-					errors = append(errors, err)
-				}
-
-				appInfos = append(appInfos, &jobInfos)
-			}(i, ns)
-
-			// get replicasets
-			go func(index int, namespace string) {
-				defer wg.Done()
-
-				jobInfos, err := k.ReplicaSetAppInfos(ReplicaSetOptions{Namespace: namespace})
 
 				if err != nil {
 					klog.Trace()

--- a/web/src/areas/overview/replicaset-view.spec.tsx
+++ b/web/src/areas/overview/replicaset-view.spec.tsx
@@ -70,33 +70,9 @@ describe('replica set overview should', () => {
     expect(wrapper.findWhere(n => n.prop('label') === 'Fully Labeled').length).toBe(1);
   })
 
-  test('have Deployments button displayed', () => {
-    const { wrapper } = setup();
-
-    expect(wrapper.find('Button').findWhere(n => n.text() === 'Deployments').length).toBe(1);
-  })
-
-  test('have ConfigMaps button displayed', () => {
-    const { wrapper } = setup();
-
-    expect(wrapper.find('Button').findWhere(n => n.text() === 'ConfigMaps').length).toBe(1);
-  })
-
-  test('have Conditions button displayed', () => {
-    const { wrapper } = setup();
-
-    expect(wrapper.find('Button').findWhere(n => n.text() === 'Conditions').length).toBe(1);
-  })
-
   test('have CardFooter (pod conditions) displayed', () => {
     const { wrapper } = setup();
 
     expect(wrapper.find('CardFooter').length).toBe(1);
-  })
-
-  test('have JsonViewModals defined', () => {
-    const { wrapper } = setup();
-
-    expect(wrapper.find('JsonViewModal').length).toBe(3);
   })
 })

--- a/web/src/areas/overview/replicaset-view.tsx
+++ b/web/src/areas/overview/replicaset-view.tsx
@@ -75,25 +75,6 @@ const ReplicaSetView = ({
                     </Col>
                   </Row>
                 </Col>
-                {!_.isEmpty(overview.conditions) || !_.isEmpty(overview.deploymentOverviews) ||!_.isEmpty(overview.configMaps)
-                ? <Col sm={5}>
-                  <Row>
-                    <Col sm={6}>
-                      {!_.isEmpty(overview.conditions)
-                      ? <Button outline color="info" onClick={() => toggleModalType('rs-condition')} block>Conditions</Button>
-                      : null}
-                    </Col>
-                    <Col sm={6}>
-                      {!_.isEmpty(overview.deploymentOverviews)
-                      ? <Button outline color="info" onClick={() => toggleModalType('rs-deployment')} block>Deployments</Button>
-                      : null}
-                      {!_.isEmpty(overview.configMaps)
-                      ? <Button outline color="info" onClick={() => toggleModalType('rs-configMap')} block>ConfigMaps</Button>
-                      : null}
-                    </Col>
-                  </Row>
-                </Col>
-                : null}
               </Row>
             </small>
           </CardBody>
@@ -104,30 +85,6 @@ const ReplicaSetView = ({
           : null
           }
         </Card>
-
-        <JsonViewModal
-          title="Conditions"
-          show={conditionsModalOpen}
-          body={overview.conditions}
-          handleClose={() => {
-            toggleModalType('rs-condition');
-          }} />
-    
-        <JsonViewModal
-          title="ConfigMaps"
-          show={configMapModalOpen}
-          body={overview.configMaps}
-          handleClose={() => {
-            toggleModalType('rs-configMap');
-          }} />
-
-        <JsonViewModal
-          title="Deployments"
-          show={deploymentModalOpen}
-          body={overview.deploymentOverviews}
-          handleClose={() => {
-            toggleModalType('rs-deployment');
-          }} />
       </div>
     )})}
   </div>


### PR DESCRIPTION
Signed-Off-By: Travis Schoenberg <traviisd@gmail.com>

No need to have the ReplicaSets returned as a separate app since they would rollup to a kind such as Service, DaemonSet, Job etc.

__What this PR does:__

Removes the separate ReplicaSet as an application for less clutter. The ReplicaSet will be part of the overview when an item is selected from the list of apps.

__Which issue(s) this PR fixes:__

Fixes #

__Does this PR introduce a user-facing change?:__

Yes, it will cause less clutter within the main apps list.
