### PR TITLE
Bump default log lines to 500

### DIFF
--- a/api/k8sv1/log.go
+++ b/api/k8sv1/log.go
@@ -77,7 +77,7 @@ func (a *LogOptions) GetTailLines() int64 {
 	if a.Tail > 0 {
 		return a.Tail
 	}
-	return 100
+	return 500
 }
 
 // UserCanAccess validates the user has access


### PR DESCRIPTION
Signed-Off-By: Travis Schoenberg traviisd@gmail.com

__What this PR does:__

Increases the default returned logs to 500 lines

__Which issue(s) this PR fixes:__

Fixes #58 

__Does this PR introduce a user-facing change?:__

No
